### PR TITLE
Mergeup 2019-07-22

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -43,7 +43,7 @@ matrix:
       language: go
       env: TEST=mynewt
       go:
-        - "1.11"
+        - "1.12"
 
 before_install:
   - |

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [coverity]: https://scan.coverity.com/projects/mcuboot
 [travis]: https://travis-ci.org/JuulLabs-OSS/mcuboot
 
-This is mcuboot, version 1.3.0
+This is mcuboot, version 1.3.1
 
 MCUboot is a secure bootloader for 32-bit MCUs.   The goal of MCUboot is to
 define a common infrastructure for the bootloader, system flash layout on

--- a/boot/bootutil/include/bootutil/sha256.h
+++ b/boot/bootutil/include/bootutil/sha256.h
@@ -61,20 +61,20 @@ typedef mbedtls_sha256_context bootutil_sha256_context;
 static inline void bootutil_sha256_init(bootutil_sha256_context *ctx)
 {
     mbedtls_sha256_init(ctx);
-    mbedtls_sha256_starts(ctx, 0);
+    (void)mbedtls_sha256_starts_ret(ctx, 0);
 }
 
 static inline void bootutil_sha256_update(bootutil_sha256_context *ctx,
                                           const void *data,
                                           uint32_t data_len)
 {
-    mbedtls_sha256_update(ctx, data, data_len);
+    (void)mbedtls_sha256_update_ret(ctx, data, data_len);
 }
 
 static inline void bootutil_sha256_finish(bootutil_sha256_context *ctx,
                                           uint8_t *output)
 {
-    mbedtls_sha256_finish(ctx, output);
+    (void)mbedtls_sha256_finish_ret(ctx, output);
 }
 #endif /* MCUBOOT_USE_MBED_TLS */
 

--- a/boot/bootutil/src/loader.c
+++ b/boot/bootutil/src/loader.c
@@ -954,6 +954,8 @@ boot_copy_sector(const struct flash_area *fap_src,
         }
 
         bytes_copied += chunk_sz;
+
+        MCUBOOT_WATCHDOG_FEED();
     }
 
     return 0;
@@ -1849,7 +1851,7 @@ split_go(int loader_slot, int split_slot, void **entry)
 
     loader_flash_id = flash_area_id_from_image_slot(loader_slot);
     rc = flash_area_open(loader_flash_id,
-                         &BOOT_IMG_AREA(&boot_data, split_slot));
+                         &BOOT_IMG_AREA(&boot_data, loader_slot));
     assert(rc == 0);
     split_flash_id = flash_area_id_from_image_slot(split_slot);
     rc = flash_area_open(split_flash_id,

--- a/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
+++ b/boot/mynewt/mcuboot_config/include/mcuboot_config/mcuboot_config.h
@@ -73,4 +73,14 @@
 
 #define MCUBOOT_MAX_IMG_SECTORS       MYNEWT_VAL(BOOTUTIL_MAX_IMG_SECTORS)
 
+#if MYNEWT_VAL(WATCHDOG_INTERVAL)
+#include <hal/hal_watchdog.h>
+#define MCUBOOT_WATCHDOG_FEED()    \
+    do {                           \
+        hal_watchdog_tickle();     \
+    } while (0)
+#else
+#define MCUBOOT_WATCHDOG_FEED()    do {} while (0)
+#endif
+
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/boot/mynewt/src/main.c
+++ b/boot/mynewt/src/main.c
@@ -218,7 +218,8 @@ main(void)
     assert(rc == 0);
 #endif
 
-#if defined(MCUBOOT_SERIAL) || defined(MCUBOOT_HAVE_LOGGING) || MYNEWT_VAL(CRYPTO)
+#if defined(MCUBOOT_SERIAL) || defined(MCUBOOT_HAVE_LOGGING) || \
+        MYNEWT_VAL(CRYPTO) || MYNEWT_VAL(HASH)
     /* initialize uart/crypto without os */
     os_dev_initialize_all(OS_DEV_INIT_PRIMARY);
     os_dev_initialize_all(OS_DEV_INIT_SECONDARY);

--- a/boot/zephyr/include/mcuboot_config/mcuboot_config.h
+++ b/boot/zephyr/include/mcuboot_config/mcuboot_config.h
@@ -78,4 +78,9 @@
 
 #endif /* !__BOOTSIM__ */
 
+#define MCUBOOT_WATCHDOG_FEED()         \
+    do {                                \
+        /* TODO: to be implemented */   \
+    } while (0)
+
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -19,7 +19,7 @@
 #include <gpio.h>
 #include <misc/__assert.h>
 #include <flash.h>
-#include <drivers/system_timer.h>
+#include <drivers/timer/system_timer.h>
 #include <usb/usb_device.h>
 #include <soc.h>
 

--- a/boot/zephyr/main.c
+++ b/boot/zephyr/main.c
@@ -19,7 +19,7 @@
 #include <gpio.h>
 #include <misc/__assert.h>
 #include <flash.h>
-#include <drivers/timer/system_timer.h>
+#include <drivers/system_timer.h>
 #include <usb/usb_device.h>
 #include <soc.h>
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -97,6 +97,7 @@ struct image_tlv {
 #define IMAGE_TLV_ECDSA224          0x21   /* ECDSA of hash output */
 #define IMAGE_TLV_ECDSA256          0x22   /* ECDSA of hash output */
 #define IMAGE_TLV_RSA3072_PSS       0x23   /* RSA3072 of hash output */
+#define IMAGE_TLV_ED25519           0x24   /* ED25519 of hash output */
 ```
 
 Optional type-length-value records (TLVs) containing image metadata are placed

--- a/docs/release-notes.md
+++ b/docs/release-notes.md
@@ -3,6 +3,25 @@
 - Table of Contents
 {:toc}
 
+## Version 1.3.1
+
+The 1.3.1 release of MCUboot consists mostly of small bug fixes and updates.
+There are no breaking changes in functionality. This release should work with
+Mynewt 1.6.0 and up, and any Zephyr `master` after sha
+f51e3c296040f73bca0e8fe1051d5ee63ce18e0d.
+
+### About this release
+
+- Fixed a revert interruption bug
+- Added ed25519 signing support
+- Added RSA-3072 signing support
+- Allow ec256 to run on CC310 interface
+- Some preparation work was done to allow for multi image support, which
+  should land in 1.4.0. This includes a simulator update for testing
+  multi-images, and a new name for slot0/slot1 which are now called
+  "primary slot" and "secondary slot".
+- Other minor bugfixes and improvements
+
 ## Version 1.3.0
 
 The 1.3.0 release of MCUboot brings in many fixes and updates.  There

--- a/repository.yml
+++ b/repository.yml
@@ -25,9 +25,10 @@ repo.versions:
     "1.1.0": "v1.1.0"
     "1.2.0": "v1.2.0"
     "1.3.0": "v1.3.0"
+    "1.3.1": "v1.3.1"
 
     "0-dev": "0.0.0"        # master
-    "0-latest": "1.3.0"     # latest stable release
-    "1-latest": "1.3.0"     # latest stable release
+    "0-latest": "1.3.1"     # latest stable release
+    "1-latest": "1.3.1"     # latest stable release
 
-    "1.0-latest": "1.3.0"
+    "1.0-latest": "1.3.1"

--- a/samples/mcuboot_config/mcuboot_config.template.h
+++ b/samples/mcuboot_config/mcuboot_config.template.h
@@ -116,4 +116,17 @@
  * "assert" is used. */
 /* #define MCUBOOT_HAVE_ASSERT_H */
 
+/*
+ * Watchdog feeding
+ */
+
+/* This macro might be implemented if the OS / HW watchdog is enabled while
+ * doing a swap upgrade and the time it takes for a swapping is long enough
+ * to cause an unwanted reset. If implementing this, the OS main.c must also
+ * enable the watchdog (if required)!
+ *
+ * #define MCUBOOT_WATCHDOG_FEED()
+ *    do { do watchdog feeding here! } while (0)
+ */
+
 #endif /* __MCUBOOT_CONFIG_H__ */

--- a/scripts/imgtool/main.py
+++ b/scripts/imgtool/main.py
@@ -42,7 +42,7 @@ def gen_ecdsa_p224(keyfile, passwd):
 
 
 def gen_ed25519(keyfile, passwd):
-    keys.Ed25519.generate().export_private(path=keyfile)
+    keys.Ed25519.generate().export_private(path=keyfile, passwd=passwd)
 
 
 valid_langs = ['c', 'rust']

--- a/scripts/requirements.txt
+++ b/scripts/requirements.txt
@@ -1,3 +1,3 @@
-cryptography
+cryptography>=2.6
 intelhex
 click

--- a/scripts/setup.py
+++ b/scripts/setup.py
@@ -2,7 +2,7 @@ import setuptools
 
 setuptools.setup(
     name="imgtool",
-    version="1.3.0",
+    version="1.3.1",
     author="The MCUboot commiters",
     description=("MCUboot's image signing and key management"),
     license="Apache Software License",


### PR DESCRIPTION
Individual Changes
------------------
853657c2 Add watchdog feeding macro
af1e02e3 [MYNEWT] Allow initialization of HASH when enabled
eadbf588 Revert Mynewt version metadata
7fea8466 Release 1.3.1
63a2bdbd Fix bug that prevents split images from working.
f99a4c79 zephyr: fix include of system_timer.h
9871cebf Update mbedTLS sha256 usage to avoid deprecation
195411f2 Add ed25519 TLV to design doc
cf17561f Update mynewt travis test to use go 1.12
4bd4c7cf Allow imgtool to generated encrypted ed25519 keys
9686e702 requirements.txt: bump cryptography Py package version